### PR TITLE
fix unchecked duplicated metavar

### DIFF
--- a/nanopass/records.ss
+++ b/nanopass/records.ss
@@ -168,7 +168,8 @@
                                       (syntax->datum (spec-name spec)) (syntax->datum lang-name))
                                     mv)))
                               (cdr specs))))
-                        (spec-meta-vars test-spec))))))))
+                        (spec-meta-vars test-spec)))
+                    (f (cdr specs)))))))
           (check-meta! name tspecs ntspecs)
           (new name entry-ntspec tspecs ntspecs #f #f #f nongen-id)))))
 


### PR DESCRIPTION
When two terminal/non-terminal definitions use the same meta-var, an error should be triggered. However, currently only the first terminal/non-terminal definition is checked for duplicated meta-var, for example,
```scheme
(import (nanopass))
(define-language Ltest
  (terminals
    (variable (v))
    (constant (v))
    (primitive (p)))
  (Expr (e)
    p))
```
triggers an error as
```
Exception in define-language: the forms variable and constant in language Ltest uses the same meta-variable v at line 4, char 16 of test.ss
```
However this doesn't
```
(import (nanopass))
(define-language Ltest
  (terminals
    (variable (v))
    (constant (p))
    (primitive (p)))
  (Expr (e)
    p))
```
This is a bug in language record's constructor, and can be fixed with this pr.